### PR TITLE
Python 3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,24 +20,25 @@
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
-from nifty_core import * ## imports `about`
-from nifty_cmaps import *
-from nifty_power import *
-from nifty_tools import *
-from nifty_explicit import *
+from __future__ import absolute_import
+from .nifty_core import * ## imports `about`
+from .nifty_cmaps import *
+from .nifty_power import *
+from .nifty_tools import *
+from .nifty_explicit import *
 
 ## optional submodule `rg`
 try:
-    from rg import *
+    from .rg import *
 except(ImportError):
     pass
 
 ## optional submodule `lm`
 try:
-    from lm import *
+    from .lm import *
 except(ImportError):
     pass
 
-from demos import *
-from pickling import *
+from .demos import *
+from .pickling import *
 

--- a/demos/__init__.py
+++ b/demos/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##
@@ -19,5 +20,5 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from demos_core import *
+from .demos_core import *
 

--- a/demos/demo_excaliwir.py
+++ b/demos/demo_excaliwir.py
@@ -32,6 +32,8 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
 from nifty import *
 
 
@@ -169,7 +171,7 @@ class problem(object):
             ## check convergence
             dtau = log(power / self.S.get_power(), base=self.S.get_power())
             iterating = (np.max(np.abs(dtau)) > 2E-2)
-            print max(np.abs(dtau))
+            print(max(np.abs(dtau)))
 
             ## update signal covariance
             self.S.set_power(power, bare=False) ## auto-updates D

--- a/demos/demo_faraday.py
+++ b/demos/demo_faraday.py
@@ -38,6 +38,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from nifty import *
 
 

--- a/demos/demo_wf1.py
+++ b/demos/demo_wf1.py
@@ -32,6 +32,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from nifty import *                                              # version 0.8.0
 
 

--- a/demos/demo_wf2.py
+++ b/demos/demo_wf2.py
@@ -32,6 +32,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from nifty import *                                              # version 0.8.0
 
 

--- a/demos/demo_wf3.py
+++ b/demos/demo_wf3.py
@@ -32,6 +32,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from nifty import *                                                   # version 0.7.0
 
 

--- a/demos/demos_core.py
+++ b/demos/demos_core.py
@@ -26,6 +26,7 @@
     the NIFTY demos calling :py:func:`get_demo_dir`.
 
 """
+from __future__ import absolute_import
 import os
 import nifty as nt
 

--- a/lm/__init__.py
+++ b/lm/__init__.py
@@ -20,6 +20,7 @@
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
+from __future__ import absolute_import
 from nifty import about
 
 from distutils.version import LooseVersion as lv
@@ -36,7 +37,7 @@ except(ImportError):
         about.infos.cprint("INFO: neither libsharp_wrapper_gl nor healpy available.")
         pass ## import nothing
     else:
-        from nifty_lm import lm_space,hp_space ## import lm & hp
+        from .nifty_lm import lm_space,hp_space ## import lm & hp
         ## TODO: change about
 else:
     try:
@@ -44,8 +45,8 @@ else:
         if lv(hp.__version__) < lv('1.8.1'):
             raise ImportError(about._errors.cprint("ERROR: installed healpy version is older than 1.8.1!"))
     except(ImportError):
-        from nifty_lm import lm_space,gl_space ## import lm & gl
+        from .nifty_lm import lm_space,gl_space ## import lm & gl
     else:        
-        from nifty_lm import lm_space,gl_space,hp_space ## import all 3
-from nifty_power_conversion_lm import *
+        from .nifty_lm import lm_space,gl_space,hp_space ## import all 3
+from .nifty_power_conversion_lm import *
 

--- a/lm/nifty_lm.py
+++ b/lm/nifty_lm.py
@@ -32,6 +32,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 #from nifty import *
 import os
 import numpy as np
@@ -43,6 +44,7 @@ from nifty import pi,                                                        \
                   random,                                                    \
                   space,                                                     \
                   field
+from six.moves import range
 #import libsharp_wrapper_gl as gl
 try:
     import libsharp_wrapper_gl as gl
@@ -826,7 +828,7 @@ class lm_space(space):
             if(other is not None):
                 if(isinstance(other,tuple)):
                     other = list(other)
-                    for ii in xrange(len(other)):
+                    for ii in range(len(other)):
                         if(isinstance(other[ii],field)):
                             other[ii] = other[ii].power(**kwargs)
                         else:
@@ -836,7 +838,7 @@ class lm_space(space):
                 else:
                     other = [self.enforce_power(other)]
                 imax = max(1,len(other)-1)
-                for ii in xrange(len(other)):
+                for ii in range(len(other)):
                     ax0.loglog(xaxes[1:],(xaxes*(2*xaxes+1)*other[ii])[1:],color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],label="graph "+str(ii+1),linestyle='-',linewidth=1.0,zorder=-ii)
                     if(mono):
                         ax0.scatter(0.5*(xaxes[1]+xaxes[2]),other[ii][0],s=20,color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],marker='o',cmap=None,norm=None,vmin=None,vmax=None,alpha=None,linewidths=None,verts=None,zorder=-ii)
@@ -878,7 +880,7 @@ class lm_space(space):
                 xmesh[4,1] = None
                 xmesh[1,4] = None
                 lm = 0
-                for mm in xrange(self.para[1]+1):
+                for mm in range(self.para[1]+1):
                     xmesh[mm][mm:] = x[lm:lm+self.para[0]+1-mm]
                     lm += self.para[0]+1-mm
 
@@ -1526,7 +1528,7 @@ class gl_space(space):
             if(other is not None):
                 if(isinstance(other,tuple)):
                     other = list(other)
-                    for ii in xrange(len(other)):
+                    for ii in range(len(other)):
                         if(isinstance(other[ii],field)):
                             other[ii] = other[ii].power(**kwargs)
                         else:
@@ -1536,7 +1538,7 @@ class gl_space(space):
                 else:
                     other = [self.enforce_power(other)]
                 imax = max(1,len(other)-1)
-                for ii in xrange(len(other)):
+                for ii in range(len(other)):
                     ax0.loglog(xaxes[1:],(xaxes*(2*xaxes+1)*other[ii])[1:],color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],label="graph "+str(ii+1),linestyle='-',linewidth=1.0,zorder=-ii)
                     if(mono):
                         ax0.scatter(0.5*(xaxes[1]+xaxes[2]),other[ii][0],s=20,color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],marker='o',cmap=None,norm=None,vmin=None,vmax=None,alpha=None,linewidths=None,verts=None,zorder=-ii)
@@ -2153,7 +2155,7 @@ class hp_space(space):
             if(other is not None):
                 if(isinstance(other,tuple)):
                     other = list(other)
-                    for ii in xrange(len(other)):
+                    for ii in range(len(other)):
                         if(isinstance(other[ii],field)):
                             other[ii] = other[ii].power(**kwargs)
                         else:
@@ -2163,7 +2165,7 @@ class hp_space(space):
                 else:
                     other = [self.enforce_power(other)]
                 imax = max(1,len(other)-1)
-                for ii in xrange(len(other)):
+                for ii in range(len(other)):
                     ax0.loglog(xaxes[1:],(xaxes*(2*xaxes+1)*other[ii])[1:],color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],label="graph "+str(ii+1),linestyle='-',linewidth=1.0,zorder=-ii)
                     if(mono):
                         ax0.scatter(0.5*(xaxes[1]+xaxes[2]),other[ii][0],s=20,color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],marker='o',cmap=None,norm=None,vmin=None,vmax=None,alpha=None,linewidths=None,verts=None,zorder=-ii)

--- a/lm/nifty_power_conversion_lm.py
+++ b/lm/nifty_power_conversion_lm.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##

--- a/nifty_cmaps.py
+++ b/nifty_cmaps.py
@@ -47,6 +47,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from matplotlib.colors import LinearSegmentedColormap as cm
 
 

--- a/nifty_core.py
+++ b/nifty_core.py
@@ -141,6 +141,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 import os
 from sys import stdout as so
 import numpy as np
@@ -148,6 +149,9 @@ import pylab as pl
 from multiprocessing import Pool as mp
 from multiprocessing import Value as mv
 from multiprocessing import Array as ma
+import six
+from six.moves import range
+from six.moves import zip
 
 
 __version__ = "1.0.7"
@@ -1659,7 +1663,7 @@ class space(object):
     ##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     def _meta_vars(self): ## > captures all nonstandard properties
-        mars = np.array([ii[1] for ii in vars(self).iteritems() if ii[0] not in ["para","datatype","discrete","vol","power_indices"]],dtype=np.object)
+        mars = np.array([ii[1] for ii in six.iteritems(vars(self)) if ii[0] not in ["para","datatype","discrete","vol","power_indices"]],dtype=np.object)
         if(np.size(mars)==0):
             return None
         else:
@@ -1682,19 +1686,19 @@ class space(object):
             if(not isinstance(x,type(self)))or(np.size(self.para)!=np.size(x.para))or(np.size(self.vol)!=np.size(x.vol)):
                 raise ValueError(about._errors.cstring("ERROR: incomparable spaces."))
             elif(self.discrete==x.discrete): ## data types are ignored
-                for ii in xrange(np.size(self.para)):
+                for ii in range(np.size(self.para)):
                     if(self.para[ii]<x.para[ii]):
                         return True
                     elif(self.para[ii]>x.para[ii]):
                         return False
-                for ii in xrange(np.size(self.vol)):
+                for ii in range(np.size(self.vol)):
                     if(self.vol[ii]<x.vol[ii]):
                         return True
                     elif(self.vol[ii]>x.vol[ii]):
                         return False
                 s_mars = self._meta_vars()
                 x_mars = x._meta_vars()
-                for ii in xrange(np.size(s_mars)):
+                for ii in range(np.size(s_mars)):
                     if(np.all(s_mars[ii]<x_mars[ii])):
                         return True
                     elif(np.any(s_mars[ii]>x_mars[ii])):
@@ -1706,19 +1710,19 @@ class space(object):
             if(not isinstance(x,type(self)))or(np.size(self.para)!=np.size(x.para))or(np.size(self.vol)!=np.size(x.vol)):
                 raise ValueError(about._errors.cstring("ERROR: incomparable spaces."))
             elif(self.discrete==x.discrete): ## data types are ignored
-                for ii in xrange(np.size(self.para)):
+                for ii in range(np.size(self.para)):
                     if(self.para[ii]<x.para[ii]):
                         return True
                     if(self.para[ii]>x.para[ii]):
                         return False
-                for ii in xrange(np.size(self.vol)):
+                for ii in range(np.size(self.vol)):
                     if(self.vol[ii]<x.vol[ii]):
                         return True
                     if(self.vol[ii]>x.vol[ii]):
                         return False
                 s_mars = self._meta_vars()
                 x_mars = x._meta_vars()
-                for ii in xrange(np.size(s_mars)):
+                for ii in range(np.size(s_mars)):
                     if(np.all(s_mars[ii]<x_mars[ii])):
                         return True
                     elif(np.any(s_mars[ii]>x_mars[ii])):
@@ -1731,19 +1735,19 @@ class space(object):
             if(not isinstance(x,type(self)))or(np.size(self.para)!=np.size(x.para))or(np.size(self.vol)!=np.size(x.vol)):
                 raise ValueError(about._errors.cstring("ERROR: incomparable spaces."))
             elif(self.discrete==x.discrete): ## data types are ignored
-                for ii in xrange(np.size(self.para)):
+                for ii in range(np.size(self.para)):
                     if(self.para[ii]>x.para[ii]):
                         return True
                     elif(self.para[ii]<x.para[ii]):
                         break
-                for ii in xrange(np.size(self.vol)):
+                for ii in range(np.size(self.vol)):
                     if(self.vol[ii]>x.vol[ii]):
                         return True
                     elif(self.vol[ii]<x.vol[ii]):
                         break
                 s_mars = self._meta_vars()
                 x_mars = x._meta_vars()
-                for ii in xrange(np.size(s_mars)):
+                for ii in range(np.size(s_mars)):
                     if(np.all(s_mars[ii]>x_mars[ii])):
                         return True
                     elif(np.any(s_mars[ii]<x_mars[ii])):
@@ -1755,19 +1759,19 @@ class space(object):
             if(not isinstance(x,type(self)))or(np.size(self.para)!=np.size(x.para))or(np.size(self.vol)!=np.size(x.vol)):
                 raise ValueError(about._errors.cstring("ERROR: incomparable spaces."))
             elif(self.discrete==x.discrete): ## data types are ignored
-                for ii in xrange(np.size(self.para)):
+                for ii in range(np.size(self.para)):
                     if(self.para[ii]>x.para[ii]):
                         return True
                     if(self.para[ii]<x.para[ii]):
                         return False
-                for ii in xrange(np.size(self.vol)):
+                for ii in range(np.size(self.vol)):
                     if(self.vol[ii]>x.vol[ii]):
                         return True
                     if(self.vol[ii]<x.vol[ii]):
                         return False
                 s_mars = self._meta_vars()
                 x_mars = x._meta_vars()
-                for ii in xrange(np.size(s_mars)):
+                for ii in range(np.size(s_mars)):
                     if(np.all(s_mars[ii]>x_mars[ii])):
                         return True
                     elif(np.any(s_mars[ii]<x_mars[ii])):
@@ -2060,7 +2064,7 @@ class point_space(space):
             else:
                 other = [self.enforce_values(other,extend=True)]
             imax = max(1,len(other)-1)
-            for ii in xrange(len(other)):
+            for ii in range(len(other)):
                 ax0.scatter(xaxes,other[ii],s=20,color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],marker='o',cmap=None,norm=None,vmin=None,vmax=None,alpha=None,label="graph "+str(ii),linewidths=None,verts=None,zorder=-ii)
             if(legend):
                 ax0.legend()
@@ -4531,10 +4535,10 @@ class nested_space(space):
             ##   len(nest')==len(nest)
             elif(len(codomain.nest)==len(self.nest)):
                 ## check permutability
-                unpaired = range(len(self.nest))
+                unpaired = list(range(len(self.nest)))
                 ambiguous = False
-                for ii in xrange(len(self.nest)):
-                    for jj in xrange(len(self.nest)):
+                for ii in range(len(self.nest)):
+                    for jj in range(len(self.nest)):
                         if(codomain.nest[ii]==self.nest[jj]):
                             if(jj in unpaired):
                                 unpaired.remove(jj)
@@ -4753,8 +4757,8 @@ class nested_space(space):
                 ## check coorder
                 if(coorder is None):
                     coorder = -np.ones(len(self.nest),dtype=np.int,order='C')
-                    for ii in xrange(len(self.nest)):
-                        for jj in xrange(len(self.nest)):
+                    for ii in range(len(self.nest)):
+                        for jj in range(len(self.nest)):
                             if(codomain.nest[ii]==self.nest[jj]):
                                 if(ii not in coorder):
                                     coorder[jj] = ii
@@ -4765,20 +4769,20 @@ class nested_space(space):
                     coorder = np.array(coorder,dtype=np.int).reshape(len(self.nest),order='C')
                     if(np.any(np.sort(coorder,axis=0,kind="quicksort",order=None)!=np.arange(len(self.nest)))):
                         raise ValueError(about._errors.cstring("ERROR: invalid input."))
-                    for ii in xrange(len(self.nest)):
+                    for ii in range(len(self.nest)):
                         if(codomain.nest[coorder[ii]]!=self.nest[ii]):
                             raise ValueError(about._errors.cstring("ERROR: invalid input."))
                 ## compute axes permutation
                 lim = np.zeros((len(self.nest),2),dtype=np.int)
-                for ii in xrange(len(self.nest)):
+                for ii in range(len(self.nest)):
                     lim[ii] = np.array([lim[ii-1][1],lim[ii-1][1]+np.size(self.nest[coorder[ii]].dim(split=True))])
                 lim = lim[coorder]
                 reorder = []
-                for ii in xrange(len(self.nest)):
-                    reorder += range(lim[ii][0],lim[ii][1])
+                for ii in range(len(self.nest)):
+                    reorder += list(range(lim[ii][0],lim[ii][1]))
                 ## permute
                 Tx = np.copy(x)
-                for ii in xrange(len(reorder)):
+                for ii in range(len(reorder)):
                     while(reorder[ii]!=ii):
                         Tx = np.swapaxes(Tx,ii,reorder[ii])
                         ii_ = reorder[reorder[ii]]
@@ -7975,7 +7979,7 @@ class diagonal_operator(operator):
         if(self.uni): ## identity
             return 1
         det = self.det()
-        if(det<>0):
+        if(det!=0):
             return 1/det
         else:
             raise ValueError(about._errors.cstring("ERROR: singular operator."))
@@ -8599,7 +8603,7 @@ class projection_operator(operator):
         else:
             assign = self.domain.enforce_shape(assign).astype(np.int).flatten(order='C')
         ## build indexing
-        self.ind = [np.where(assign==ii)[0] for ii in xrange(np.max(assign,axis=None,out=None)+1) if ii in assign]
+        self.ind = [np.where(assign==ii)[0] for ii in range(np.max(assign,axis=None,out=None)+1) if ii in assign]
 
         self.sym = True
 #        about.infos.cprint("INFO: pseudo unitary projection operator.")
@@ -8634,11 +8638,11 @@ class projection_operator(operator):
         """
         rho = np.empty(len(self.ind),dtype=np.int,order='C')
         if(self.domain.dim(split=False)==self.domain.dof()): ## no hidden degrees of freedom
-            for ii in xrange(len(self.ind)):
+            for ii in range(len(self.ind)):
                 rho[ii] = len(self.ind[ii])
         else: ## hidden degrees of freedom
             mof = np.round(np.real(self.domain.calc_weight(self.domain.get_meta_volume(total=False),power=-1).flatten(order='C')),decimals=0,out=None).astype(np.int) ## meta degrees of freedom
-            for ii in xrange(len(self.ind)):
+            for ii in range(len(self.ind)):
                 rho[ii] = np.sum(mof[self.ind[ii]],axis=None,dtype=np.int,out=None)
         return rho
 
@@ -8690,7 +8694,7 @@ class projection_operator(operator):
         else:
             Px = np.zeros((len(self.ind),self.domain.dim(split=False)),dtype=self.target.datatype,order='C')
             x_ = x.val.flatten(order='C')
-            for bb in xrange(self.bands()):
+            for bb in range(self.bands()):
                 Px[bb][self.ind[bb]] += x_[self.ind[bb]]
             Px = field(self.target,val=Px,target=nested_space([point_space(len(self.ind),datatype=x.target.datatype),x.target]))
             return Px
@@ -8761,7 +8765,7 @@ class projection_operator(operator):
         ## evaluate
         y = self._debriefing(x,x_,self.target,False)
         ## split if ...
-        if(kwargs.get("split",False))and((kwargs.has_key("band"))or(kwargs.has_key("bandsup"))):
+        if(kwargs.get("split",False))and(("band" in kwargs)or("bandsup" in kwargs)):
             return y,x-y
         else:
             return y
@@ -8836,7 +8840,7 @@ class projection_operator(operator):
             x *= np.round(np.real(self.domain.calc_weight(self.domain.get_meta_volume(total=False),power=-1).flatten(order='C')),decimals=0,out=None).astype(np.int) ## meta degrees of freedom
 
         tr = np.empty(self.bands(),dtype=x.dtype,order='C')
-        for bb in xrange(self.bands()):
+        for bb in range(self.bands()):
             tr[bb] = np.sum(x[self.ind[bb]],axis=None,dtype=None,out=None)
         return tr
 
@@ -9255,7 +9259,7 @@ class response_operator(operator):
                 assignments = np.size(assign,axis=0)
                 if(np.ndim(assign)!=2)or(np.size(assign,axis=1)!=np.size(self.domain.dim(split=True))):
                     raise ValueError(about._errors.cstring("ERROR: invalid input."))
-                for ii in xrange(np.size(assign,axis=1)):
+                for ii in range(np.size(assign,axis=1)):
                     if(np.any(assign[:,ii]>=self.domain.dim(split=True)[ii]))or(np.any(assign[:,ii]<-self.domain.dim(split=True)[ii])):
                         raise IndexError(about._errors.cstring("ERROR: invalid bounds."))
                 if(assignments==len(np.unique(np.ravel_multi_index(assign.T,self.domain.dim(split=True),mode="raise",order='C'),return_index=False,return_inverse=False))):
@@ -9340,7 +9344,7 @@ class response_operator(operator):
         elif(isinstance(self.assign,list)):
             x_[self.assign] += x.val.flatten(order='C')
         else:
-            for ii in xrange(np.size(self.assign,axis=0)):
+            for ii in range(np.size(self.assign,axis=0)):
                 x_[np.array([self.assign[ii]]).T.tolist()] += x[ii]
         ## mask
         x_ *= self.mask
@@ -9578,7 +9582,7 @@ class probing(object):
             elif(op==function):
                 function = op.times
             ## check whether correctly bound
-            if(op!=function.im_self):
+            if(op!=function.__self__):
                 raise NameError(about._errors.cstring("ERROR: invalid input."))
             ## check given shape and domain
             if(domain is None)or(not isinstance(domain,space)):
@@ -9822,7 +9826,7 @@ class probing(object):
         pool = mp(processes=self.ncpu,initializer=_share._init_share,initargs=(_sum,_num,_var),maxtasksperchild=self.nper)
         try:
             ## pooling
-            pool.map_async(self._serial_probing,zip(seed,np.arange(self.nrun,dtype=np.int)),chunksize=None,callback=None).get(timeout=None)
+            pool.map_async(self._serial_probing,list(zip(seed,np.arange(self.nrun,dtype=np.int))),chunksize=None,callback=None).get(timeout=None)
             ## close and join pool
             about.infos.cflush(" done.")
             pool.close()
@@ -9851,7 +9855,7 @@ class probing(object):
         _sum = 0
         _num = 0
         _var = 0
-        for ii in xrange(self.nrun):
+        for ii in range(self.nrun):
             result = self._single_probing((np.random.randint(10**8,high=None,size=None),ii)) ## tuple(seed,idnum)
             if(result is not None):
                 _sum += result ## result: {scalar, np.array}
@@ -10059,7 +10063,7 @@ class trace_probing(probing):
         elif(op==function):
             function = op.times
         ## check whether correctly bound
-        if(op!=function.im_self):
+        if(op!=function.__self__):
             raise NameError(about._errors.cstring("ERROR: invalid input."))
         self.function = function
 
@@ -10232,7 +10236,7 @@ class trace_probing(probing):
         pool = mp(processes=self.ncpu,initializer=_share._init_share,initargs=(_sum,_num,_var),maxtasksperchild=self.nper)
         try:
             ## pooling
-            pool.map_async(self._serial_probing,zip(seed,np.arange(self.nrun,dtype=np.int)),chunksize=None,callback=None).get(timeout=None)
+            pool.map_async(self._serial_probing,list(zip(seed,np.arange(self.nrun,dtype=np.int))),chunksize=None,callback=None).get(timeout=None)
             ## close and join pool
             about.infos.cflush(" done.")
             pool.close()
@@ -10453,7 +10457,7 @@ class diagonal_probing(probing):
         elif(op==function):
             function = op.times
         ## check whether correctly bound
-        if(op!=function.im_self):
+        if(op!=function.__self__):
             raise NameError(about._errors.cstring("ERROR: invalid input."))
         self.function = function
 
@@ -10662,7 +10666,7 @@ class diagonal_probing(probing):
         pool = mp(processes=self.ncpu,initializer=_share._init_share,initargs=(_sum,_num,_var),maxtasksperchild=self.nper)
         try:
             ## pooling
-            pool.map_async(self._serial_probing,zip(seed,np.arange(self.nrun,dtype=np.int)),chunksize=None,callback=None).get(timeout=None)
+            pool.map_async(self._serial_probing,list(zip(seed,np.arange(self.nrun,dtype=np.int))),chunksize=None,callback=None).get(timeout=None)
             ## close and join pool
             about.infos.cflush(" done.")
             pool.close()

--- a/nifty_power.py
+++ b/nifty_power.py
@@ -41,14 +41,16 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 from scipy.interpolate import interp1d as ip ## FIXME: conflicts with sphinx's autodoc
 #from nifty_core import *
 import numpy as np
-from nifty_core import about,                                                \
+from .nifty_core import about,                                                \
                        space,                                                \
                        field,                                                \
                        projection_operator
-import smoothing as gs
+from . import smoothing as gs
+from six.moves import range
 
 
 ##-----------------------------------------------------------------------------
@@ -269,7 +271,7 @@ def _calc_laplace(kindex): ## > computes Laplace operator and integrand
     klim = len(kindex)
     L = np.zeros((klim,klim))
     I = np.zeros(klim)
-    for jj in xrange(2,klim-1): ## leave out {0,1,kmax}
+    for jj in range(2,klim-1): ## leave out {0,1,kmax}
         L[jj,jj-1] = 2/(dl2[jj-1]*dl1[jj-1])
         L[jj,jj] = -2/dl2[jj-1]*(1/dl1[jj]+1/dl1[jj-1])
         L[jj,jj+1] = 2/(dl2[jj-1]*dl1[jj])
@@ -468,16 +470,16 @@ def infer_power(m,domain=None,Sk=None,D=None,pindex=None,pundex=None,kindex=None
         Sk = projection_operator(domain,assign=pindex)
     elif(not isinstance(Sk,projection_operator))or(not hasattr(Sk,"pseudo_tr")):
         raise TypeError(about._errors.cstring("ERROR: invalid input."))
-    elif(Sk.domain<>domain):
+    elif(Sk.domain!=domain):
         raise ValueError(about._errors.cstring("ERROR: invalid input."))
     ## check critical parameters
     if(not np.isscalar(q)):
         q = np.array(q,dtype=domain.vol.dtype).flatten()
-        if(np.size(q)<>np.size(kindex)):
+        if(np.size(q)!=np.size(kindex)):
             raise ValueError(about._errors.cstring("ERROR: invalid input."))
     if(not np.isscalar(alpha)):
         alpha = np.array(alpha,dtype=domain.vol.dtype).flatten()
-        if(np.size(alpha)<>np.size(kindex)):
+        if(np.size(alpha)!=np.size(kindex)):
             raise ValueError(about._errors.cstring("ERROR: invalid input."))
     ## check perception (delta,epsilon)
     if(perception is None):
@@ -491,7 +493,7 @@ def infer_power(m,domain=None,Sk=None,D=None,pindex=None,pundex=None,kindex=None
     ## check smothness variance
     if(not np.isscalar(var)):
         var = np.array(var,dtype=domain.vol.dtype).flatten()
-        if(np.size(var)<>np.size(kindex)):
+        if(np.size(var)!=np.size(kindex)):
             raise ValueError(about._errors.cstring("ERROR: invalid input."))
 
     ## trace(s) of B

--- a/nifty_power_conversion.py
+++ b/nifty_power_conversion.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##

--- a/nifty_tools.py
+++ b/nifty_tools.py
@@ -37,9 +37,10 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 #from nifty_core import *
 import numpy as np
-from nifty_core import notification,about,                                   \
+from .nifty_core import notification,about,                                   \
                        space,                                                \
                        field,                                                \
                        operator,diagonal_operator

--- a/pickling.py
+++ b/pickling.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##
@@ -19,16 +20,16 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import copy_reg as cr
+import six.moves.copyreg as cr
 from types import MethodType as mt
 
 
 ##-----------------------------------------------------------------------------
 
 def _pickle_method(method):
-    fct_name = method.im_func.__name__
-    obj = method.im_self
-    cl = method.im_class
+    fct_name = method.__func__.__name__
+    obj = method.__self__
+    cl = method.__self__.__class__
     ## handle mangled function name
     if(fct_name.startswith("__"))and(not fct_name.endswith("__")):
         cl_name = cl.__name__.lstrip("_")

--- a/rg/__init__.py
+++ b/rg/__init__.py
@@ -20,6 +20,7 @@
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
-from nifty_rg import *
-from nifty_power_conversion_rg import *
+from __future__ import absolute_import
+from .nifty_rg import *
+from .nifty_power_conversion_rg import *
 

--- a/rg/gfft_rg.py
+++ b/rg/gfft_rg.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##
@@ -24,6 +26,7 @@
 
 import numpy as np
 import warnings
+from six.moves import range
 
 
 def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
@@ -114,7 +117,7 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
     VERSION = "0.2.1"
 
     if verbose:
-        print "gfft v. "+VERSION
+        print("gfft v. "+VERSION)
 
     ############################################################################
     # Set some global variables
@@ -250,8 +253,8 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
             'number of dimensions!')
 
     if verbose:
-        print 'Requested mode = ' + mode_types[mode]
-        print "Number of dimensions = " + str(N)
+        print('Requested mode = ' + mode_types[mode])
+        print("Number of dimensions = " + str(N))
 
     ############################################################################
     # Figure out which axes should have which transforms applied to them
@@ -287,8 +290,8 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
 #            warnings.warn('No Fourier transformation requested, only '+\
 #                'shifting will be performed!')
             if verbose:
-                print "No Fourier transformation requested, only "+\
-                    "shifting will be performed!"
+                print("No Fourier transformation requested, only "+\
+                    "shifting will be performed!")
             mode = MODE_RR #Since gridding will not be needed, just use RR mode
 
     ############################################################################
@@ -358,8 +361,8 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
     # Print operation summary
 
     if verbose:
-        print ""
-        print "Axis#, FFT, IFFT, ZCIN, ZCOUT, HERM"
+        print("")
+        print("Axis#, FFT, IFFT, ZCIN, ZCOUT, HERM")
 
         for i in range(N):
             pstr = str(N)+', '
@@ -389,7 +392,7 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
             else:
                 pstr = pstr + 'False'
 
-        print pstr
+        print(pstr)
 
     ############################################################################
     # Do MODE_RR transform
@@ -411,8 +414,8 @@ def gfft(inp, in_ax=[], out_ax=[], ftmachine='fft', in_zero_center=True, \
             out = np.fft.fftshift(out, axes=postshift_axes)
 
         if verbose:
-            print "Done!"
-            print ""
+            print("Done!")
+            print("")
 
         return out
 

--- a/rg/nifty_power_conversion_rg.py
+++ b/rg/nifty_power_conversion_rg.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##

--- a/rg/nifty_rg.py
+++ b/rg/nifty_rg.py
@@ -32,6 +32,7 @@
 
 """
 from __future__ import division
+from __future__ import absolute_import
 #from nifty import *
 import os
 import numpy as np
@@ -43,12 +44,13 @@ from nifty.nifty_core import about,                                          \
                              space,                                          \
                              field
 import nifty.smoothing as gs
-import powerspectrum as gp
+from . import powerspectrum as gp
+from six.moves import range
 try:
     import gfft as gf
 except(ImportError):
     about.infos.cprint('INFO: "plain" gfft version 0.1.0')
-    import gfft_rg as gf
+    from . import gfft_rg as gf
 
 
 ##-----------------------------------------------------------------------------
@@ -1055,7 +1057,7 @@ class rg_space(space):
             if(other is not None):
                 if(isinstance(other,tuple)):
                     other = list(other)
-                    for ii in xrange(len(other)):
+                    for ii in range(len(other)):
                         if(isinstance(other[ii],field)):
                             other[ii] = other[ii].power(**kwargs)
                         else:
@@ -1065,7 +1067,7 @@ class rg_space(space):
                 else:
                     other = [self.enforce_power(other,size=np.size(xaxes),kindex=xaxes)]
                 imax = max(1,len(other)-1)
-                for ii in xrange(len(other)):
+                for ii in range(len(other)):
                     ax0.loglog(xaxes[1:],(xaxes**norm*other[ii])[1:],color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],label="graph "+str(ii+1),linestyle='-',linewidth=1.0,zorder=-ii)
                     if(mono):
                         ax0.scatter(0.5*(xaxes[1]+xaxes[2]),other[ii][0],s=20,color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],marker='o',cmap=None,norm=None,vmin=None,vmax=None,alpha=None,linewidths=None,verts=None,zorder=-ii)
@@ -1116,7 +1118,7 @@ class rg_space(space):
                     else:
                         other = [self.enforce_values(other,extend=True)]
                     imax = max(1,len(other)-1)
-                    for ii in xrange(len(other)):
+                    for ii in range(len(other)):
                         ax0graph(xaxes,other[ii],color=[max(0.0,1.0-(2*ii/imax)**2),0.5*((2*ii-imax)/imax)**2,max(0.0,1.0-(2*(ii-imax)/imax)**2)],label="graph "+str(ii+1),linestyle='-',linewidth=1.0,zorder=-ii)
                     if("error" in kwargs):
                         error = self.enforce_values(np.absolute(kwargs.get("error")),extend=True)

--- a/rg/powerspectrum.py
+++ b/rg/powerspectrum.py
@@ -22,7 +22,9 @@
 ## TODO: cythonize
 
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
+from six.moves import range
 
 
 def draw_vector_nd(axes,dgrid,ps,symtype=0,fourier=False,zerocentered=False,kpack=None):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ## NIFTY (Numerical Information Field Theory) has been developed at the
 ## Max-Planck-Institute for Astrophysics.
 ##

--- a/smoothing.py
+++ b/smoothing.py
@@ -23,7 +23,9 @@
 ## TODO: doc strings
 
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
+from six.moves import range
 #import gfft as gf
 
 
@@ -106,7 +108,7 @@ def smooth_power_bf(power, k, exclude=1, smooth_length=None):
     mdk = np.r_[0.5*(mk[1]-mk[0]),0.5*(mk[2:]-mk[:-2]),0.5*(mk[-1]-mk[-2])]
 
     p_smooth = np.empty(mpower.shape)
-    for i in xrange(len(p_smooth)):
+    for i in range(len(p_smooth)):
         C = np.exp(-(mk-mk[i])**2/(2.*smooth_length**2))*mdk
         p_smooth[i] = np.sum(C*mpower)/np.sum(C)
 
@@ -148,7 +150,7 @@ def smooth_power_2s(power, k, exclude=1, smooth_length=None):
     mdk = np.r_[0.5*(mk[1]-mk[0]),0.5*(mk[2:]-mk[:-2]),0.5*(mk[-1]-mk[-2])]
 
     p_smooth = np.empty(mpower.shape)
-    for i in xrange(len(p_smooth)):
+    for i in range(len(p_smooth)):
         l = i-int(2*smooth_length/mdk[i])-1
         l = max(l,0)
         u = i+int(2*smooth_length/mdk[i])+2


### PR DESCRIPTION
This is a follow-up feature request to https://github.com/information-field-theory/d3po/issues/7 to add Python 3 support to Nifty / d3po.

This pull request is the result of running [python-modernize](https://pypi.python.org/pypi/modernize) on Nifty:

```
python-modernize -w .
```

Apparently some manual fixes are needed in addition, on Python 3 I get:

```
$ python demo_excaliwir.py 
WARNING: global setting 'about.lm2gl' corrected.
Traceback (most recent call last):
  File "demo_excaliwir.py", line 212, in <module>
    p = problem(x_space, log=True)
  File "demo_excaliwir.py", line 85, in __init__
    self.d = self.R(self.s) + n
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/nifty/nifty_core.py", line 5758, in __add__
    if(x.domain.datatype>self.domain.datatype):
TypeError: unorderable types: type() > type()
```

So I'm not suggesting you merge this PR (although probably it's OK, everything should still work in Python 3), this is just a first attempt. The right way would be to add some tests first that exercise the code to make sure results don't change on Python 2 and are identical on Python 3.

Do you have someone that could add Python 3 support it in the coming weeks?
